### PR TITLE
fix(command-button): play label pulse animation in production

### DIFF
--- a/components/evil-buttons/command-button.tsx
+++ b/components/evil-buttons/command-button.tsx
@@ -115,7 +115,7 @@ export const CommandButton = React.forwardRef<
         />
         <motion.span
           key={`label-${pulse}`}
-          initial={false}
+          initial={{ scale: 1, y: 0 }}
           animate={
             pulse ? { scale: [1, 0.96, 1], y: [0, 1, 0] } : undefined
           }


### PR DESCRIPTION
## Problem
`CommandButton` looked fine on `localhost` but did nothing visible on production (https://www.evilbuttons.com/docs/command-button) when pressing Cmd/Ctrl+S. No console errors.

## Root cause
The keyboard handler was never broken. it fires and correctly calls `preventDefault()` in every environment. The **animation** was the problem.

The label span used `initial={false}` together with `key={`label-${pulse}`}`. The changing key remounts the span on every pulse, and with `initial={false}` Motion treats the animate target as already applied on that fresh mount, so it snaps to the end state instead of playing the keyframes. Dev's mount/scheduling let it slip through; the optimized production build reliably skips it.

## Fix
Give the label an explicit `initial={{ scale: 1, y: 0 }}` (mirrors the overlayspan, which already uses an explicit initial and animated fine).