### PR TITLE
fix(landing-page): scale showcase buttons to fit on small breakpoints

### DIFF
--- a/components/landing/fit-to-container.tsx
+++ b/components/landing/fit-to-container.tsx
@@ -20,6 +20,7 @@ export function FitToContainer({
   const outer = useRef<HTMLDivElement>(null);
   const inner = useRef<HTMLDivElement>(null);
   const scaleRef = useRef(1); // currently-applied scale, written to the DOM as --fit-scale
+  const naturalRef = useRef<{ width: number; height: number } | null>(null); // cached unscaled size
 
   useLayoutEffect(() => {
     const outerEl = outer.current;
@@ -31,27 +32,20 @@ export function FitToContainer({
       const availableHeight = outerEl.clientHeight;
       if (!availableWidth || !availableHeight) return;
 
-      // Rects include the currently-applied transform, so divide it back out to
-      // recover the natural (unscaled) footprint. Re-derived each pass so it
-      // stays correct if the effect re-runs while a scale is already applied.
-      const appliedScale = scaleRef.current || 1;
-      let left = Infinity, top = Infinity, right = -Infinity, bottom = -Infinity;
-      for (const node of [innerEl, ...innerEl.querySelectorAll<HTMLElement>("*")]) {
-        const rect = node.getBoundingClientRect();
-        if (rect.width === 0 && rect.height === 0) continue;
-        if (rect.left < left) left = rect.left;
-        if (rect.top < top) top = rect.top;
-        if (rect.right > right) right = rect.right;
-        if (rect.bottom > bottom) bottom = rect.bottom;
+      // Cache the natural footprint; it only changes when the button reflows,
+      // which clears the cache below. The rect includes the applied transform,
+      // so divide it back out to recover the unscaled size.
+      if (!naturalRef.current) {
+        const bounds = getVisualBounds(innerEl);
+        if (!bounds || !bounds.width || !bounds.height) return;
+        const appliedScale = scaleRef.current || 1;
+        naturalRef.current = { width: bounds.width / appliedScale, height: bounds.height / appliedScale };
       }
-      if (!isFinite(left)) return;
-      const naturalWidth = (right - left) / appliedScale;
-      const naturalHeight = (bottom - top) / appliedScale;
-      if (!naturalWidth || !naturalHeight) return;
 
       // Write straight to the DOM, not state: avoids re-rendering the child on
       // every resize when the value only drives one style.
-      const nextScale = Math.min(max, availableWidth / naturalWidth, availableHeight / naturalHeight);
+      const { width, height } = naturalRef.current;
+      const nextScale = Math.min(max, availableWidth / width, availableHeight / height);
       if (Math.abs(nextScale - scaleRef.current) > 0.005) {
         scaleRef.current = nextScale;
         innerEl.style.setProperty("--fit-scale", String(nextScale));
@@ -60,7 +54,11 @@ export function FitToContainer({
 
     // Measure synchronously: ResizeObserver fires in hidden tabs (rAF doesn't),
     // and we only mutate --fit-scale, never the observed border-box, so no loop.
-    const observer = new ResizeObserver(measure);
+    const observer = new ResizeObserver((entries) => {
+      // Button reflowed → its natural size may have changed; drop the cache.
+      if (entries.some((entry) => entry.target === innerEl)) naturalRef.current = null;
+      measure();
+    });
     observer.observe(outerEl);
     observer.observe(innerEl);
     measure();
@@ -90,4 +88,20 @@ export function FitToContainer({
       </div>
     </div>
   );
+}
+
+/** Bounding box enclosing an element and everything it paints, including children
+ *  that overflow its layout box (glows, negative-inset gradients). Null if empty. */
+function getVisualBounds(root: HTMLElement): { width: number; height: number } | null {
+  let left = Infinity, top = Infinity, right = -Infinity, bottom = -Infinity;
+  for (const node of [root, ...root.querySelectorAll<HTMLElement>("*")]) {
+    const rect = node.getBoundingClientRect();
+    if (rect.width === 0 && rect.height === 0) continue;
+    if (rect.left < left) left = rect.left;
+    if (rect.top < top) top = rect.top;
+    if (rect.right > right) right = rect.right;
+    if (rect.bottom > bottom) bottom = rect.bottom;
+  }
+  if (!isFinite(left)) return null;
+  return { width: right - left, height: bottom - top };
 }

--- a/components/landing/fit-to-container.tsx
+++ b/components/landing/fit-to-container.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { useLayoutEffect, useRef, type ReactNode } from "react";
+
+/**
+ * Scales its child down to fit the available space, like an SVG `viewBox`. Fits
+ * the union of every descendant's box, so content painting outside its layout
+ * box (glows, negative-inset gradients) is included rather than clipped — a
+ * child that paints far outside its box will shrink the whole component.
+ */
+export function FitToContainer({
+  children,
+  max = 1, // never upscale past natural size
+  className,
+}: {
+  children: ReactNode;
+  max?: number;
+  className?: string;
+}) {
+  const outer = useRef<HTMLDivElement>(null);
+  const inner = useRef<HTMLDivElement>(null);
+  const scaleRef = useRef(1); // currently-applied scale, written to the DOM as --fit-scale
+
+  useLayoutEffect(() => {
+    const outerEl = outer.current;
+    const innerEl = inner.current;
+    if (!outerEl || !innerEl) return;
+
+    const measure = () => {
+      const availableWidth = outerEl.clientWidth;
+      const availableHeight = outerEl.clientHeight;
+      if (!availableWidth || !availableHeight) return;
+
+      // Rects include the currently-applied transform, so divide it back out to
+      // recover the natural (unscaled) footprint. Re-derived each pass so it
+      // stays correct if the effect re-runs while a scale is already applied.
+      const appliedScale = scaleRef.current || 1;
+      let left = Infinity, top = Infinity, right = -Infinity, bottom = -Infinity;
+      for (const node of [innerEl, ...innerEl.querySelectorAll<HTMLElement>("*")]) {
+        const rect = node.getBoundingClientRect();
+        if (rect.width === 0 && rect.height === 0) continue;
+        if (rect.left < left) left = rect.left;
+        if (rect.top < top) top = rect.top;
+        if (rect.right > right) right = rect.right;
+        if (rect.bottom > bottom) bottom = rect.bottom;
+      }
+      if (!isFinite(left)) return;
+      const naturalWidth = (right - left) / appliedScale;
+      const naturalHeight = (bottom - top) / appliedScale;
+      if (!naturalWidth || !naturalHeight) return;
+
+      // Write straight to the DOM, not state: avoids re-rendering the child on
+      // every resize when the value only drives one style.
+      const nextScale = Math.min(max, availableWidth / naturalWidth, availableHeight / naturalHeight);
+      if (Math.abs(nextScale - scaleRef.current) > 0.005) {
+        scaleRef.current = nextScale;
+        innerEl.style.setProperty("--fit-scale", String(nextScale));
+      }
+    };
+
+    // Measure synchronously: ResizeObserver fires in hidden tabs (rAF doesn't),
+    // and we only mutate --fit-scale, never the observed border-box, so no loop.
+    const observer = new ResizeObserver(measure);
+    observer.observe(outerEl);
+    observer.observe(innerEl);
+    measure();
+
+    return () => observer.disconnect();
+  }, [max]);
+
+  return (
+    <div
+      ref={outer}
+      className={className}
+      style={{
+        display: "grid",
+        // minmax(0, 1fr) clamps the track to the container so an oversized child
+        // overflows symmetrically and scales around its true center (plain
+        // 1fr/auto grows to max-content and off-centers it).
+        gridTemplateColumns: "minmax(0, 1fr)",
+        gridTemplateRows: "minmax(0, 1fr)",
+        placeItems: "center",
+        overflow: "hidden",
+        width: "100%",
+        height: "100%",
+      }}
+    >
+      <div ref={inner} style={{ transform: "scale(var(--fit-scale, 1))", transformOrigin: "center" }}>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/components/landing/landing-page.tsx
+++ b/components/landing/landing-page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import Image from "next/image";
 import { Copy, ArrowUpRight } from "@phosphor-icons/react";
 import { ThemeSync } from "@/components/theme-sync";
+import { FitToContainer } from "@/components/landing/fit-to-container";
 import { siteConfig } from "@/lib/seo";
 
 import { AquaButton } from "@/components/evil-buttons/aqua-button";
@@ -168,7 +169,7 @@ function ButtonCell({ item }: { item: ButtonShowcase }) {
   return (
     <div className="group relative flex aspect-square flex-col overflow-hidden border-r border-b border-border bg-background transition-colors hover:bg-muted/30">
       <div className="flex flex-1 items-center justify-center p-4">
-        {item.render()}
+        <FitToContainer>{item.render()}</FitToContainer>
       </div>
       <div className="relative flex h-10 items-center justify-center font-mono text-[11px] font-medium text-muted-foreground">
         {item.name}


### PR DESCRIPTION
Closes [#15](https://github.com/radiumcoders/Evil-Buttons/issues/15)

On small breakpoints, grid cells shrink below some buttons intrinsic width, so they overflow and clip. This was mainly noticeable on `EvilEyeButton` where it has`min-w-52` plus its glow pushes it outside its cell. 

Fixed with a new `FitToContainer` wrapper that measures true visual bounds (glow and gradients included) via `ResizeObserver` and applies `scale = min(1, cellW/contentW, cellH/contentH)` through a `--fit-scale` CSS variable, like an SVG `viewBox`. Buttons that already fit are left alone and resizing doesn't re-render the child. Registry button components are untouched. 