### PR TITLE
DialKit landing preview with button picker

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -251,3 +251,87 @@ html.dark .docs-content .shiki span {
   font-weight: var(--shiki-dark-font-weight) !important;
   text-decoration: var(--shiki-dark-text-decoration) !important;
 }
+
+/* DialKit — match Evil Buttons page tokens and sharp corners */
+.dialkit-root {
+  --dial-radius: 0;
+  --dial-panel-offset-top: 5.5rem;
+  font-family: var(--font-sans), system-ui, sans-serif;
+}
+
+.dialkit-panel[data-position="top-left"] {
+  top: var(--dial-panel-offset-top) !important;
+  left: 1.5rem !important;
+}
+
+.dialkit-root[data-theme="light"] {
+  --dial-surface: color-mix(in oklab, var(--foreground) 4%, transparent);
+  --dial-surface-hover: color-mix(in oklab, var(--foreground) 8%, transparent);
+  --dial-surface-active: color-mix(in oklab, var(--foreground) 10%, transparent);
+  --dial-surface-subtle: color-mix(in oklab, var(--foreground) 6%, transparent);
+  --dial-text-root: var(--foreground);
+  --dial-text-section: var(--muted-foreground);
+  --dial-text-label: var(--muted-foreground);
+  --dial-text-focus: var(--foreground);
+  --dial-text-primary: var(--foreground);
+  --dial-text-secondary: var(--muted-foreground);
+  --dial-text-tertiary: color-mix(in oklab, var(--muted-foreground) 70%, transparent);
+  --dial-border: var(--border);
+  --dial-border-hover: color-mix(in oklab, var(--foreground) 18%, transparent);
+  --dial-glass-bg: var(--popover);
+  --dial-dropdown-bg: var(--popover);
+  --dial-backdrop-blur: 0px;
+  --dial-shadow: 0 1px 0 var(--border);
+  --dial-shadow-collapsed: 0 1px 0 var(--border);
+  --dial-shadow-dropdown: 0 8px 24px color-mix(in oklab, var(--foreground) 12%, transparent);
+}
+
+.dialkit-root[data-theme="dark"] {
+  --dial-surface: color-mix(in oklab, var(--foreground) 6%, transparent);
+  --dial-surface-hover: color-mix(in oklab, var(--foreground) 10%, transparent);
+  --dial-surface-active: color-mix(in oklab, var(--foreground) 12%, transparent);
+  --dial-surface-subtle: color-mix(in oklab, var(--foreground) 8%, transparent);
+  --dial-text-root: var(--foreground);
+  --dial-text-section: var(--muted-foreground);
+  --dial-text-label: var(--muted-foreground);
+  --dial-text-focus: var(--foreground);
+  --dial-text-primary: var(--foreground);
+  --dial-text-secondary: var(--muted-foreground);
+  --dial-text-tertiary: color-mix(in oklab, var(--muted-foreground) 70%, transparent);
+  --dial-border: var(--border);
+  --dial-border-hover: color-mix(in oklab, var(--foreground) 22%, transparent);
+  --dial-glass-bg: var(--popover);
+  --dial-dropdown-bg: var(--popover);
+  --dial-backdrop-blur: 0px;
+  --dial-shadow: 0 1px 0 var(--border);
+  --dial-shadow-collapsed: 0 1px 0 var(--border);
+  --dial-shadow-dropdown: 0 12px 32px color-mix(in oklab, black 45%, transparent);
+}
+
+.dialkit-panel-inner {
+  border-radius: 0 !important;
+  backdrop-filter: none !important;
+  -webkit-backdrop-filter: none !important;
+  padding-bottom: 12px !important;
+}
+
+.dialkit-root
+  .dialkit-folder-root
+  > .dialkit-folder-content
+  > .dialkit-folder-inner {
+  padding-bottom: 8px !important;
+}
+
+.dialkit-root .dialkit-panel-inner[data-collapsed="true"] {
+  border-radius: 0 !important;
+}
+
+.dialkit-root .dialkit-toggle-thumb,
+.dialkit-root .dialkit-shortcuts-row,
+.dialkit-root .dialkit-shortcuts-row-key,
+.dialkit-root .dialkit-select-trigger,
+.dialkit-root .dialkit-select-content,
+.dialkit-root .dialkit-preset-item,
+.dialkit-root .dialkit-color-swatch {
+  border-radius: 0 !important;
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -264,21 +264,14 @@ html.dark .docs-content .shiki span {
   left: 1.5rem !important;
 }
 
-@media (max-width: 639px) {
-  .dialkit-root {
-    --dial-panel-offset-top: 0;
-  }
+.dialkit-panel[data-position="bottom-left"] {
+  bottom: 3.75rem !important;
+  left: 1rem !important;
+  max-width: calc(100vw - 2rem);
+}
 
-  .dialkit-panel[data-position="top-left"] {
-    top: auto !important;
-    bottom: 3.75rem !important;
-    left: 1rem !important;
-    max-width: calc(100vw - 2rem);
-  }
-
-  .dialkit-panel[data-position="top-left"] .dialkit-panel-inner {
-    max-width: min(280px, calc(100vw - 2rem));
-  }
+.dialkit-panel[data-position="bottom-left"] .dialkit-panel-inner {
+  max-width: min(280px, calc(100vw - 2rem));
 }
 
 .dialkit-root[data-theme="light"] {

--- a/app/globals.css
+++ b/app/globals.css
@@ -264,6 +264,23 @@ html.dark .docs-content .shiki span {
   left: 1.5rem !important;
 }
 
+@media (max-width: 639px) {
+  .dialkit-root {
+    --dial-panel-offset-top: 0;
+  }
+
+  .dialkit-panel[data-position="top-left"] {
+    top: auto !important;
+    bottom: 3.75rem !important;
+    left: 1rem !important;
+    max-width: calc(100vw - 2rem);
+  }
+
+  .dialkit-panel[data-position="top-left"] .dialkit-panel-inner {
+    max-width: min(280px, calc(100vw - 2rem));
+  }
+}
+
 .dialkit-root[data-theme="light"] {
   --dial-surface: color-mix(in oklab, var(--foreground) 4%, transparent);
   --dial-surface-hover: color-mix(in oklab, var(--foreground) 8%, transparent);

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
 import { Geist, Geist_Mono, Inter, Doto } from "next/font/google";
-import { DialRoot } from "dialkit";
+import { AppDialRoot } from "@/components/dial-root";
 import "dialkit/styles.css";
 import "./globals.css";
 import { JsonLd } from "@/components/seo/json-ld";
@@ -58,7 +58,7 @@ export default function RootLayout({
         <Analytics />
         <SpeedInsights />
         {children}
-        <DialRoot />
+        <AppDialRoot />
       </body>
     </html>
   );

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,6 @@
 import { Geist, Geist_Mono, Inter, Doto } from "next/font/google";
+import { DialRoot } from "dialkit";
+import "dialkit/styles.css";
 import "./globals.css";
 import { JsonLd } from "@/components/seo/json-ld";
 import { cn } from "@/lib/utils";
@@ -56,6 +58,7 @@ export default function RootLayout({
         <Analytics />
         <SpeedInsights />
         {children}
+        <DialRoot />
       </body>
     </html>
   );

--- a/components/dial-root.tsx
+++ b/components/dial-root.tsx
@@ -2,9 +2,16 @@
 
 import { DialRoot } from "dialkit";
 import { useAppTheme } from "@/hooks/use-app-theme";
+import { useIsMobile } from "@/hooks/use-is-mobile";
 
 export function AppDialRoot() {
   const theme = useAppTheme();
+  const isMobile = useIsMobile();
 
-  return <DialRoot theme={theme} position="top-left" />;
+  return (
+    <DialRoot
+      theme={theme}
+      position={isMobile ? "bottom-left" : "top-left"}
+    />
+  );
 }

--- a/components/dial-root.tsx
+++ b/components/dial-root.tsx
@@ -1,0 +1,10 @@
+"use client";
+
+import { DialRoot } from "dialkit";
+import { useAppTheme } from "@/hooks/use-app-theme";
+
+export function AppDialRoot() {
+  const theme = useAppTheme();
+
+  return <DialRoot theme={theme} position="top-left" />;
+}

--- a/components/landing/landing-page.tsx
+++ b/components/landing/landing-page.tsx
@@ -4,9 +4,9 @@ import { DeferredMount } from "@/components/landing/deferred-mount";
 import { FitToContainer } from "@/components/landing/fit-to-container";
 import { ThemeSync } from "@/components/theme-sync";
 import { siteConfig } from "@/lib/seo";
-import { ArrowUpRight, Copy } from "@phosphor-icons/react";
+import { ArrowUpRight } from "@phosphor-icons/react";
 import Link from "next/link";
-import { type ReactNode, useEffect, useRef, useState } from "react";
+import { type ReactNode, useState } from "react";
 
 import { AquaButton } from "@/components/evil-buttons/aqua-button";
 import { BrutalButton } from "@/components/evil-buttons/brutal-button";
@@ -37,6 +37,13 @@ import { DemonicButton } from "../evil-buttons/demonic-button";
 import { PillButton } from "@/components/evil-buttons/pill-button";
 import { ConfettiButton } from "@/components/evil-buttons/confetti-button";
 import { HoldConfirmButton } from "@/components/evil-buttons/hold-confirm-button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 
 type ButtonShowcase = {
   name: string;
@@ -45,9 +52,6 @@ type ButtonShowcase = {
   render: () => ReactNode;
 };
 
-// Static stand-in shown for the always-on WebGL buttons until their grid cell
-// scrolls into view. Approximates the real button's footprint (rounded, dark
-// pill) so swapping in the live shader causes no layout shift.
 function WebGLPlaceholder({ label }: { label: string }) {
   return (
     <span className="inline-flex min-h-16 min-w-52 items-center justify-center rounded-full border border-border bg-neutral-950 px-9 py-4 font-mono text-sm font-medium uppercase tracking-widest text-neutral-500">
@@ -254,122 +258,84 @@ const showcase: ButtonShowcase[] = [
   },
 ];
 
-function ButtonCell({ item }: { item: ButtonShowcase }) {
-  const [copied, setCopied] = useState(false);
-  const timerRef = useRef<number | null>(null);
-
-  useEffect(() => {
-    return () => {
-      if (timerRef.current !== null) clearTimeout(timerRef.current);
-    };
-  }, []);
-
-  const command = `npx shadcn@latest add @evilbuttons/${item.registryName}`;
-
-  async function handleCopy(e: React.MouseEvent) {
-    e.preventDefault();
-    e.stopPropagation();
-    await navigator.clipboard.writeText(command);
-    setCopied(true);
-    if (timerRef.current !== null) clearTimeout(timerRef.current);
-    timerRef.current = window.setTimeout(() => setCopied(false), 2000);
-  }
-
-  return (
-    <div className="group relative flex aspect-square flex-col overflow-hidden border-r border-b border-border bg-background transition-colors hover:bg-muted/30">
-      <div className="absolute top-0 left-0 z-10 px-3 py-2 font-mono text-[11px] font-medium text-muted-foreground">
-        {item.name}
-      </div>
-      <div className="flex flex-1 items-center justify-center p-4">
-        <FitToContainer>{item.render()}</FitToContainer>
-      </div>
-      <div className="absolute inset-x-0 bottom-0 flex h-10 translate-y-full gap-px border-t border-border bg-background transition-transform duration-300 ease-[cubic-bezier(0.85,0,0.15,1)] group-hover:translate-y-0">
-        <Link
-          href={item.href}
-          className="flex flex-1 items-center justify-center gap-1 text-[11px] font-medium text-foreground transition-colors hover:bg-muted/50"
-        >
-          <ArrowUpRight className="size-3" />
-          Docs
-        </Link>
-        <button
-          onClick={handleCopy}
-          className="flex flex-1 items-center justify-center gap-1 bg-primary text-[11px] font-medium text-primary-foreground transition-colors hover:bg-primary/90"
-        >
-          <Copy className="size-3" weight={copied ? "fill" : "regular"} />
-          {copied ? "Copied" : "Copy"}
-        </button>
-      </div>
-    </div>
-  );
-}
-
 export function LandingPage() {
+  const [selected, setSelected] = useState(showcase[0].registryName);
+  const active = showcase.find((item) => item.registryName === selected) ?? showcase[0];
+
   return (
-    <div className="flex h-dvh flex-col overflow-hidden bg-background text-foreground xl:flex-row">
+    <div className="flex h-dvh flex-col overflow-hidden bg-background text-foreground">
       <ThemeSync />
 
-      <header className="shrink-0 border-b border-border px-6 py-6 xl:flex xl:w-[340px] xl:shrink-0 xl:flex-col xl:justify-between xl:border-b-0 xl:px-8 xl:py-10">
-        <div>
-          <Link
-            href="/"
-            className="inline-flex w-fit transition-opacity hover:opacity-85"
-          >
-            <div className="flex items-center justify-center gap-2">
-              <img
-                src="/logo.png"
-                alt={siteConfig.name}
-                width={288}
-                height={192}
-                className="h-auto w-14 sm:w-16"
-              />
-              <h1 className="text-2xl font-doto font-black tracking-tighter leading-5">
-                Evil <br /> Buttons
-              </h1>
-            </div>
-          </Link>
-          <h1 className="mt-4 max-w-2xl text-2xl font-semibold tracking-tight text-balance leading-tight xl:mt-8 xl:text-3xl">
-            Animated buttons, built with an evil touch.
-          </h1>
-          <p className="mt-2 max-w-xl text-sm text-muted-foreground text-balance xl:mt-4">
-            A shadcn/ui registry of {showcase.length} interactive button
-            components. Live previews, copy-paste docs, one-command CLI
-            installs.
-          </p>
-          <div className="mt-4 flex items-center gap-2 xl:mt-8 xl:flex-col">
-            <Link
-              href="/docs"
-              className="inline-flex h-9 w-full items-center justify-center bg-primary px-4 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
-            >
-              Browse Docs
-            </Link>
-            <a
-              href={siteConfig.github}
-              target="_blank"
-              rel="noreferrer"
-              className="inline-flex h-9 w-full items-center justify-center border border-border bg-background px-4 text-sm font-medium text-foreground transition-colors hover:bg-accent"
-            >
-              GitHub
-            </a>
-          </div>
-        </div>
+      <header className="flex shrink-0 items-center justify-between gap-4 border-b border-border px-6 py-4">
+        <Link
+          href="/"
+          className="inline-flex w-fit items-center gap-2 transition-opacity hover:opacity-85"
+        >
+          <img
+            src="/logo.png"
+            alt={siteConfig.name}
+            width={288}
+            height={192}
+            className="h-auto w-10"
+          />
+          <span className="font-doto text-lg font-black tracking-tighter">
+            Evil Buttons
+          </span>
+        </Link>
 
-        <div className="mt-4 flex items-center gap-4 xl:mt-0 xl:flex-col xl:items-start xl:gap-2">
-          <p className="font-mono text-[11px] uppercase tracking-[0.2em] text-muted-foreground">
-            {showcase.length} Components
-          </p>
-          <p className="font-mono text-[11px] text-muted-foreground">
-            © {new Date().getFullYear()} {siteConfig.author.name}
-          </p>
+        <div className="flex items-center gap-3">
+          <Select value={selected} onValueChange={setSelected}>
+            <SelectTrigger className="w-52">
+              <SelectValue placeholder="Pick a button" />
+            </SelectTrigger>
+            <SelectContent>
+              {showcase.map((item) => (
+                <SelectItem key={item.registryName} value={item.registryName}>
+                  {item.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+
+          <Link
+            href={active.href}
+            className="hidden items-center gap-1 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground sm:inline-flex"
+          >
+            Docs
+            <ArrowUpRight className="size-3.5" />
+          </Link>
         </div>
       </header>
 
-      <main className="docs-scroll flex-1 overflow-y-auto">
-        <div className="grid grid-cols-2 border-t border-border md:grid-cols-3 xl:border-l xl:border-t-0">
-          {showcase.map((item) => (
-            <ButtonCell key={item.name} item={item} />
-          ))}
+      <main className="relative flex flex-1 items-center justify-center p-8">
+        <div className="absolute inset-0 flex items-center justify-center">
+          <FitToContainer className="h-full max-h-[min(70vh,560px)] w-full max-w-3xl">
+            {active.render()}
+          </FitToContainer>
         </div>
       </main>
+
+      <footer className="flex shrink-0 items-center justify-between border-t border-border px-6 py-3">
+        <p className="font-mono text-[11px] uppercase tracking-[0.2em] text-muted-foreground">
+          {showcase.length} components
+        </p>
+        <div className="flex items-center gap-4">
+          <Link
+            href="/docs"
+            className="text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+          >
+            Browse Docs
+          </Link>
+          <a
+            href={siteConfig.github}
+            target="_blank"
+            rel="noreferrer"
+            className="text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+          >
+            GitHub
+          </a>
+        </div>
+      </footer>
     </div>
   );
 }

--- a/components/landing/landing-page.tsx
+++ b/components/landing/landing-page.tsx
@@ -4,6 +4,7 @@ import { FitToContainer } from "@/components/landing/fit-to-container";
 import { ButtonPreview } from "@/components/landing/previews";
 import { showcase } from "@/components/landing/showcase";
 import { ThemeSync } from "@/components/theme-sync";
+import { ThemeToggle } from "@/components/theme-toggle";
 import { useAppTheme } from "@/hooks/use-app-theme";
 import { siteConfig } from "@/lib/seo";
 import { ArrowUpRight } from "@phosphor-icons/react";
@@ -45,6 +46,7 @@ export function LandingPage() {
         </Link>
 
         <div className="flex w-full min-w-0 items-center gap-2 sm:w-auto sm:gap-3">
+          <ThemeToggle />
           <Select value={selected} onValueChange={setSelected}>
             <SelectTrigger className="w-full min-w-0 rounded-none sm:w-52">
               <SelectValue placeholder="Pick a button" />

--- a/components/landing/landing-page.tsx
+++ b/components/landing/landing-page.tsx
@@ -27,7 +27,7 @@ export function LandingPage() {
     <div className="flex h-dvh flex-col overflow-hidden bg-background text-foreground">
       <ThemeSync />
 
-      <header className="flex shrink-0 items-center justify-between gap-4 px-6 py-4">
+      <header className="grid shrink-0 gap-3 px-4 py-3 sm:flex sm:items-center sm:justify-between sm:gap-4 sm:px-6 sm:py-4">
         <Link
           href="/"
           className="inline-flex w-fit items-center gap-2 transition-opacity hover:opacity-85"
@@ -37,16 +37,16 @@ export function LandingPage() {
             alt={siteConfig.name}
             width={288}
             height={192}
-            className="h-auto w-10"
+            className="h-auto w-9 sm:w-10"
           />
-          <span className="font-doto text-lg font-black tracking-tighter">
+          <span className="font-doto text-base font-black tracking-tighter sm:text-lg">
             Evil Buttons
           </span>
         </Link>
 
-        <div className="flex items-center gap-3">
+        <div className="flex w-full min-w-0 items-center gap-2 sm:w-auto sm:gap-3">
           <Select value={selected} onValueChange={setSelected}>
-            <SelectTrigger className="w-52 rounded-none">
+            <SelectTrigger className="w-full min-w-0 rounded-none sm:w-52">
               <SelectValue placeholder="Pick a button" />
             </SelectTrigger>
             <SelectContent className="rounded-none">
@@ -64,7 +64,7 @@ export function LandingPage() {
 
           <Link
             href={active.href}
-            className="hidden items-center gap-1 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground sm:inline-flex"
+            className="hidden shrink-0 items-center gap-1 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground sm:inline-flex"
           >
             Docs
             <ArrowUpRight className="size-3.5" />
@@ -72,22 +72,20 @@ export function LandingPage() {
         </div>
       </header>
 
-      <main className="relative flex flex-1 items-center justify-center p-8">
-        <div className="absolute inset-0 flex items-center justify-center">
-          <FitToContainer className="h-full max-h-[min(70vh,560px)] w-full max-w-3xl">
-            <ButtonPreview key={`${selected}-${theme}`} registryName={selected} />
-          </FitToContainer>
-        </div>
+      <main className="flex min-h-0 flex-1 items-center justify-center px-4 py-4 sm:px-8 sm:py-8">
+        <FitToContainer className="h-full max-h-[min(52dvh,380px)] w-full max-w-3xl sm:max-h-[min(70vh,560px)]">
+          <ButtonPreview key={`${selected}-${theme}`} registryName={selected} />
+        </FitToContainer>
       </main>
 
-      <footer className="flex shrink-0 items-center justify-between px-6 py-3">
-        <p className="font-mono text-[11px] uppercase tracking-[0.2em] text-muted-foreground">
+      <footer className="flex shrink-0 items-center justify-between gap-3 px-4 py-3 sm:px-6">
+        <p className="shrink-0 font-mono text-[10px] uppercase tracking-[0.15em] text-muted-foreground sm:text-[11px] sm:tracking-[0.2em]">
           {showcase.length} components
         </p>
-        <div className="flex items-center gap-4">
+        <div className="flex min-w-0 items-center gap-3 sm:gap-4">
           <Link
             href="/docs"
-            className="text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+            className="truncate text-xs font-medium text-muted-foreground transition-colors hover:text-foreground sm:text-sm"
           >
             Browse Docs
           </Link>
@@ -95,7 +93,7 @@ export function LandingPage() {
             href={siteConfig.github}
             target="_blank"
             rel="noreferrer"
-            className="text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+            className="shrink-0 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground sm:text-sm"
           >
             GitHub
           </a>

--- a/components/landing/landing-page.tsx
+++ b/components/landing/landing-page.tsx
@@ -1,42 +1,14 @@
 "use client";
 
-import { DeferredMount } from "@/components/landing/deferred-mount";
 import { FitToContainer } from "@/components/landing/fit-to-container";
+import { ButtonPreview } from "@/components/landing/previews";
+import { showcase } from "@/components/landing/showcase";
 import { ThemeSync } from "@/components/theme-sync";
+import { useAppTheme } from "@/hooks/use-app-theme";
 import { siteConfig } from "@/lib/seo";
 import { ArrowUpRight } from "@phosphor-icons/react";
 import Link from "next/link";
-import { type ReactNode, useState } from "react";
-
-import { AquaButton } from "@/components/evil-buttons/aqua-button";
-import { BrutalButton } from "@/components/evil-buttons/brutal-button";
-import { CaptchaButton } from "@/components/evil-buttons/captcha-button";
-import ChromeButton from "@/components/evil-buttons/chrome-button";
-import { ClickPowerUp } from "@/components/evil-buttons/click-powerup";
-import { CommandButton } from "@/components/evil-buttons/command-button";
-import { CooldownButton } from "@/components/evil-buttons/cooldown-button";
-import { CopyButton } from "@/components/evil-buttons/copy-button";
-import { DoubtButton } from "@/components/evil-buttons/doubt-button";
-import DitherButton from "@/components/evil-buttons/dither-button";
-import EvilEyeButton from "@/components/evil-buttons/evil-eye-button";
-import { FrameButton } from "@/components/evil-buttons/frame-button";
-import GlitchButton from "@/components/evil-buttons/glitch-button";
-import GridButton from "@/components/evil-buttons/grid-button";
-import { HighlightButton } from "@/components/evil-buttons/highlight-button";
-import { HoldButton } from "@/components/evil-buttons/hold-button";
-import MinimalButton from "@/components/evil-buttons/minimal";
-import { MorphStatusButton } from "@/components/evil-buttons/morph-status-button";
-import MoviePassButton from "@/components/evil-buttons/movie-pass";
-import { RevealButton } from "@/components/evil-buttons/reveal-button";
-import ShinyButton from "@/components/evil-buttons/shiny-button";
-import { SlideToDetonate } from "@/components/evil-buttons/slide-to-detonate";
-import StickyButton from "@/components/evil-buttons/sticky";
-import { ThreeDButton } from "@/components/evil-buttons/3d-button";
-import TrollButton from "@/components/evil-buttons/troll-button";
-import { DemonicButton } from "../evil-buttons/demonic-button";
-import { PillButton } from "@/components/evil-buttons/pill-button";
-import { ConfettiButton } from "@/components/evil-buttons/confetti-button";
-import { HoldConfirmButton } from "@/components/evil-buttons/hold-confirm-button";
+import { useState } from "react";
 import {
   Select,
   SelectContent,
@@ -45,228 +17,17 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 
-type ButtonShowcase = {
-  name: string;
-  href: string;
-  registryName: string;
-  render: () => ReactNode;
-};
-
-function WebGLPlaceholder({ label }: { label: string }) {
-  return (
-    <span className="inline-flex min-h-16 min-w-52 items-center justify-center rounded-full border border-border bg-neutral-950 px-9 py-4 font-mono text-sm font-medium uppercase tracking-widest text-neutral-500">
-      {label}
-    </span>
-  );
-}
-
-const showcase: ButtonShowcase[] = [
-  {
-    name: "RevealButton",
-    href: "/docs/reveal-button",
-    registryName: "reveal-button",
-    render: () => <RevealButton label="Hold to reveal" />,
-  },
-  {
-    name: "CommandButton",
-    href: "/docs/command-button",
-    registryName: "command-button",
-    render: () => <CommandButton shortcut="mod+s">Save</CommandButton>,
-  },
-  {
-    name: "CopyButton",
-    href: "/docs/copy-button",
-    registryName: "copy-button",
-    render: () => <CopyButton value="npx evil-buttons@latest init" />,
-  },
-  {
-    name: "ClickPowerUp",
-    href: "/docs/click-power-up",
-    registryName: "click-powerup",
-    render: () => <ClickPowerUp>Doom</ClickPowerUp>,
-  },
-  {
-    name: "DitherButton",
-    href: "/docs/dither-button",
-    registryName: "dither-button",
-    render: () => <DitherButton>Run It</DitherButton>,
-  },
-  {
-    name: "HoldButton",
-    href: "/docs/hold-button",
-    registryName: "hold-button",
-    render: () => <HoldButton />,
-  },
-  {
-    name: "DemonicButton",
-    href: "/docs/demonic-button",
-    registryName: "demonic-button",
-    render: () => <DemonicButton label="Currupt the World" />,
-  },
-  {
-    name: "EvilEyeButton",
-    href: "/docs/evil-eye-button",
-    registryName: "evil-eye-button",
-    render: () => (
-      <DeferredMount placeholder={<WebGLPlaceholder label="Doom" />}>
-        <EvilEyeButton>Doom</EvilEyeButton>
-      </DeferredMount>
-    ),
-  },
-  {
-    name: "AquaButton",
-    href: "/docs/aqua-button",
-    registryName: "aqua-button",
-    render: () => <AquaButton>Deploy Doom</AquaButton>,
-  },
-  {
-    name: "BrutalButton",
-    href: "/docs/brutal-button",
-    registryName: "brutal-button",
-    render: () => <BrutalButton>Click Me</BrutalButton>,
-  },
-  {
-    name: "ChromeButton",
-    href: "/docs/chrome-button",
-    registryName: "chrome-button",
-    render: () => (
-      <DeferredMount placeholder={<WebGLPlaceholder label="Chromy" />}>
-        <ChromeButton>Chromy</ChromeButton>
-      </DeferredMount>
-    ),
-  },
-  {
-    name: "FrameButton",
-    href: "/docs/frame-button",
-    registryName: "frame-button",
-    render: () => <FrameButton>Deploy</FrameButton>,
-  },
-  {
-    name: "GlitchButton",
-    href: "/docs/glitch-button",
-    registryName: "glitch-button",
-    render: () => <GlitchButton>Launch</GlitchButton>,
-  },
-  {
-    name: "GridButton",
-    href: "/docs/grid-button",
-    registryName: "grid-button",
-    render: () => <GridButton>Click</GridButton>,
-  },
-  {
-    name: "HighlightButton",
-    href: "/docs/highlight-button",
-    registryName: "highlight-button",
-    render: () => <HighlightButton>Send</HighlightButton>,
-  },
-  {
-    name: "MinimalButton",
-    href: "/docs/minimal-button",
-    registryName: "minimal",
-    render: () => <MinimalButton>Apply</MinimalButton>,
-  },
-  {
-    name: "MoviePassButton",
-    href: "/docs/movie-pass",
-    registryName: "movie-pass",
-    render: () => <MoviePassButton>Deploy Doom</MoviePassButton>,
-  },
-  {
-    name: "ShinyButton",
-    href: "/docs/shiny-button",
-    registryName: "shiny-button",
-    render: () => <ShinyButton>Search</ShinyButton>,
-  },
-  {
-    name: "StickyButton",
-    href: "/docs/sticky-button",
-    registryName: "sticky",
-    render: () => <StickyButton>Try to Click</StickyButton>,
-  },
-  {
-    name: "ThreeDButton",
-    href: "/docs/3d-button",
-    registryName: "3d-button",
-    render: () => <ThreeDButton>Continue</ThreeDButton>,
-  },
-  {
-    name: "TrollButton",
-    href: "/docs/troll-button",
-    registryName: "troll-button",
-    render: () => <TrollButton>Click Me</TrollButton>,
-  },
-  {
-    name: "CaptchaButton",
-    href: "/docs/captcha-button",
-    registryName: "captcha-button",
-    render: () => <CaptchaButton>Deploy Doom</CaptchaButton>,
-  },
-  {
-    name: "DoubtButton",
-    href: "/docs/doubt-button",
-    registryName: "doubt-button",
-    render: () => <DoubtButton>Delete everything</DoubtButton>,
-  },
-  {
-    name: "SlideToDetonate",
-    href: "/docs/slide-to-detonate",
-    registryName: "slide-to-detonate",
-    render: () => <SlideToDetonate>Slide to detonate</SlideToDetonate>,
-  },
-  {
-    name: "MorphStatusButton",
-    href: "/docs/morph-status-button",
-    registryName: "morph-status-button",
-    render: () => (
-      <MorphStatusButton
-        onClick={() => new Promise((resolve) => setTimeout(resolve, 1200))}
-      >
-        Save changes
-      </MorphStatusButton>
-    ),
-  },
-  {
-    name: "CooldownButton",
-    href: "/docs/cooldown-button",
-    registryName: "cooldown-button",
-    render: () => <CooldownButton>Send it</CooldownButton>,
-  },
-  {
-    name: "PillButton",
-    href: "/docs/pill-button",
-    registryName: "pill-button",
-    render: () => (
-      <PillButton
-        primaryLabel="Off"
-        secondaryLabel="On"
-        primaryClassName="bg-neutral-950 text-neutral-200"
-        secondaryClassName="bg-primary text-primary-foreground"
-      />
-    ),
-  },
-  {
-    name: "ConfettiButton",
-    href: "/docs/confetti-button",
-    registryName: "confetti-button",
-    render: () => <ConfettiButton>Celebrate</ConfettiButton>,
-  },
-  {
-    name: "HoldConfirmButton",
-    href: "/docs/hold-confirm-button",
-    registryName: "hold-confirm-button",
-    render: () => <HoldConfirmButton />,
-  },
-];
-
 export function LandingPage() {
+  const theme = useAppTheme();
   const [selected, setSelected] = useState(showcase[0].registryName);
-  const active = showcase.find((item) => item.registryName === selected) ?? showcase[0];
+  const active =
+    showcase.find((item) => item.registryName === selected) ?? showcase[0];
 
   return (
     <div className="flex h-dvh flex-col overflow-hidden bg-background text-foreground">
       <ThemeSync />
 
-      <header className="flex shrink-0 items-center justify-between gap-4 border-b border-border px-6 py-4">
+      <header className="flex shrink-0 items-center justify-between gap-4 px-6 py-4">
         <Link
           href="/"
           className="inline-flex w-fit items-center gap-2 transition-opacity hover:opacity-85"
@@ -285,12 +46,16 @@ export function LandingPage() {
 
         <div className="flex items-center gap-3">
           <Select value={selected} onValueChange={setSelected}>
-            <SelectTrigger className="w-52">
+            <SelectTrigger className="w-52 rounded-none">
               <SelectValue placeholder="Pick a button" />
             </SelectTrigger>
-            <SelectContent>
+            <SelectContent className="rounded-none">
               {showcase.map((item) => (
-                <SelectItem key={item.registryName} value={item.registryName}>
+                <SelectItem
+                  key={item.registryName}
+                  value={item.registryName}
+                  className="rounded-none"
+                >
                   {item.name}
                 </SelectItem>
               ))}
@@ -310,12 +75,12 @@ export function LandingPage() {
       <main className="relative flex flex-1 items-center justify-center p-8">
         <div className="absolute inset-0 flex items-center justify-center">
           <FitToContainer className="h-full max-h-[min(70vh,560px)] w-full max-w-3xl">
-            {active.render()}
+            <ButtonPreview key={`${selected}-${theme}`} registryName={selected} />
           </FitToContainer>
         </div>
       </main>
 
-      <footer className="flex shrink-0 items-center justify-between border-t border-border px-6 py-3">
+      <footer className="flex shrink-0 items-center justify-between px-6 py-3">
         <p className="font-mono text-[11px] uppercase tracking-[0.2em] text-muted-foreground">
           {showcase.length} components
         </p>

--- a/components/landing/previews/index.tsx
+++ b/components/landing/previews/index.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import type { ComponentType } from "react";
+import {
+  RevealButtonPreview,
+  HoldButtonPreview,
+  HoldConfirmButtonPreview,
+  SlideToDetonatePreview,
+  DoubtButtonPreview,
+  CaptchaButtonPreview,
+  CooldownButtonPreview,
+  MorphStatusButtonPreview,
+} from "./interaction";
+import {
+  BrutalButtonPreview,
+  DitherButtonPreview,
+  GlitchButtonPreview,
+  EvilEyeButtonPreview,
+  AquaButtonPreview,
+  FrameButtonPreview,
+  HighlightButtonPreview,
+  ConfettiButtonPreview,
+} from "./visual";
+import {
+  CommandButtonPreview,
+  CopyButtonPreview,
+  ClickPowerUpPreview,
+  PillButtonPreview,
+} from "./utility";
+import {
+  DemonicButtonPreview,
+  ChromeButtonPreview,
+  GridButtonPreview,
+  MinimalButtonPreview,
+  MoviePassButtonPreview,
+  ShinyButtonPreview,
+  StickyButtonPreview,
+  ThreeDButtonPreview,
+  TrollButtonPreview,
+} from "./simple";
+
+const buttonPreviews: Record<string, ComponentType> = {
+  "reveal-button": RevealButtonPreview,
+  "command-button": CommandButtonPreview,
+  "copy-button": CopyButtonPreview,
+  "click-powerup": ClickPowerUpPreview,
+  "dither-button": DitherButtonPreview,
+  "hold-button": HoldButtonPreview,
+  "demonic-button": DemonicButtonPreview,
+  "evil-eye-button": EvilEyeButtonPreview,
+  "aqua-button": AquaButtonPreview,
+  "brutal-button": BrutalButtonPreview,
+  "chrome-button": ChromeButtonPreview,
+  "frame-button": FrameButtonPreview,
+  "glitch-button": GlitchButtonPreview,
+  "grid-button": GridButtonPreview,
+  "highlight-button": HighlightButtonPreview,
+  minimal: MinimalButtonPreview,
+  "movie-pass": MoviePassButtonPreview,
+  "shiny-button": ShinyButtonPreview,
+  sticky: StickyButtonPreview,
+  "3d-button": ThreeDButtonPreview,
+  "troll-button": TrollButtonPreview,
+  "captcha-button": CaptchaButtonPreview,
+  "doubt-button": DoubtButtonPreview,
+  "slide-to-detonate": SlideToDetonatePreview,
+  "morph-status-button": MorphStatusButtonPreview,
+  "cooldown-button": CooldownButtonPreview,
+  "pill-button": PillButtonPreview,
+  "confetti-button": ConfettiButtonPreview,
+  "hold-confirm-button": HoldConfirmButtonPreview,
+};
+
+export function ButtonPreview({ registryName }: { registryName: string }) {
+  const Preview = buttonPreviews[registryName];
+  if (!Preview) return null;
+  return <Preview />;
+}

--- a/components/landing/previews/interaction.tsx
+++ b/components/landing/previews/interaction.tsx
@@ -1,0 +1,205 @@
+"use client";
+
+import { useDialKit } from "dialkit";
+import { useThemedDialKit } from "./theme";
+import { RevealButton } from "@/components/evil-buttons/reveal-button";
+import { HoldButton } from "@/components/evil-buttons/hold-button";
+import { HoldConfirmButton } from "@/components/evil-buttons/hold-confirm-button";
+import { SlideToDetonate } from "@/components/evil-buttons/slide-to-detonate";
+import { DoubtButton } from "@/components/evil-buttons/doubt-button";
+import { CaptchaButton } from "@/components/evil-buttons/captcha-button";
+import { CooldownButton } from "@/components/evil-buttons/cooldown-button";
+import { MorphStatusButton } from "@/components/evil-buttons/morph-status-button";
+
+export function RevealButtonPreview() {
+  const p = useDialKit(
+    "RevealButton",
+    {
+      label: "Reveal",
+      hiddenLabel: "Hidden",
+      maskedValue: "•••• •••• ••••",
+      secret: "sk_live_••••_9xQ4",
+      revealMode: {
+        type: "select",
+        options: ["hold", "toggle"],
+        default: "hold",
+      },
+    },
+    { id: "reveal-button" },
+  );
+
+  return (
+    <RevealButton
+      label={p.label}
+      hiddenLabel={p.hiddenLabel}
+      maskedValue={p.maskedValue}
+      secret={p.secret}
+      revealMode={p.revealMode as "hold" | "toggle"}
+    />
+  );
+}
+
+export function HoldButtonPreview() {
+  const p = useDialKit(
+    "HoldButton",
+    {
+      label: "Hold to delete",
+      holdingLabel: "Keep holding…",
+      successLabel: "Deleted",
+      duration: [1500, 500, 5000],
+      resetAfter: [1400, 0, 5000],
+    },
+    { id: "hold-button" },
+  );
+
+  return (
+    <HoldButton
+      label={p.label}
+      holdingLabel={p.holdingLabel}
+      successLabel={p.successLabel}
+      duration={p.duration}
+      resetAfter={p.resetAfter}
+    />
+  );
+}
+
+export function HoldConfirmButtonPreview() {
+  const p = useThemedDialKit(
+    "HoldConfirmButton",
+    (isDark) => ({
+      label: "Hold to confirm",
+      holdingLabel: "Keep holding…",
+      successLabel: "Confirmed",
+      duration: [2000, 500, 5000],
+      resetAfter: [1600, 0, 5000],
+      minScale: [0.9, 0.7, 1, 0.01],
+      ring: {
+        size: [280, 100, 400],
+        strokeWidth: [12, 4, 24],
+        color: isDark ? "#5eead4" : "#0d9488",
+      },
+    }),
+    { id: "hold-confirm-button" },
+  );
+
+  return (
+    <HoldConfirmButton
+      label={p.label}
+      holdingLabel={p.holdingLabel}
+      successLabel={p.successLabel}
+      duration={p.duration}
+      resetAfter={p.resetAfter}
+      minScale={p.minScale}
+      ringSize={p.ring.size}
+      ringStrokeWidth={p.ring.strokeWidth}
+      ringColor={p.ring.color}
+    />
+  );
+}
+
+export function SlideToDetonatePreview() {
+  const p = useDialKit(
+    "SlideToDetonate",
+    {
+      label: "Slide to detonate",
+      successLabel: "Detonated",
+      threshold: [0.95, 0.5, 1, 0.01],
+      resetAfter: [1600, 0, 5000],
+    },
+    { id: "slide-to-detonate" },
+  );
+
+  return (
+    <SlideToDetonate
+      label={p.label}
+      successLabel={p.successLabel}
+      threshold={p.threshold}
+      resetAfter={p.resetAfter}
+    />
+  );
+}
+
+export function DoubtButtonPreview() {
+  const p = useDialKit(
+    "DoubtButton",
+    {
+      label: "Delete everything",
+      successLabel: "Too late.",
+      resetAfter: [1600, 0, 5000],
+    },
+    { id: "doubt-button" },
+  );
+
+  return (
+    <DoubtButton
+      label={p.label}
+      successLabel={p.successLabel}
+      resetAfter={p.resetAfter}
+    />
+  );
+}
+
+export function CaptchaButtonPreview() {
+  const p = useDialKit(
+    "CaptchaButton",
+    {
+      label: "Deploy Doom",
+      successLabel: "Deployed",
+      resetAfter: [1600, 0, 5000],
+    },
+    { id: "captcha-button" },
+  );
+
+  return (
+    <CaptchaButton
+      label={p.label}
+      successLabel={p.successLabel}
+      resetAfter={p.resetAfter}
+    />
+  );
+}
+
+export function CooldownButtonPreview() {
+  const p = useDialKit(
+    "CooldownButton",
+    {
+      label: "Send it",
+      cooldown: [3000, 1000, 10000],
+      showCountdown: true,
+    },
+    { id: "cooldown-button" },
+  );
+
+  return (
+    <CooldownButton
+      label={p.label}
+      cooldown={p.cooldown}
+      showCountdown={p.showCountdown}
+    />
+  );
+}
+
+export function MorphStatusButtonPreview() {
+  const p = useDialKit(
+    "MorphStatusButton",
+    {
+      label: "Save changes",
+      loadingLabel: "Working…",
+      successLabel: "Done",
+      errorLabel: "It broke. Your fault.",
+      resetAfter: [1800, 0, 5000],
+    },
+    { id: "morph-status-button" },
+  );
+
+  return (
+    <MorphStatusButton
+      label={p.label}
+      loadingLabel={p.loadingLabel}
+      successLabel={p.successLabel}
+      errorLabel={p.errorLabel}
+      resetAfter={p.resetAfter}
+      onClick={() => new Promise((resolve) => setTimeout(resolve, 1200))}
+    />
+  );
+}

--- a/components/landing/previews/shared.tsx
+++ b/components/landing/previews/shared.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { DeferredMount } from "@/components/landing/deferred-mount";
+import type { ReactNode } from "react";
+
+export function WebGLPlaceholder({ label }: { label: string }) {
+  return (
+    <span className="inline-flex min-h-16 min-w-52 items-center justify-center border border-border bg-muted px-9 py-4 font-mono text-sm font-medium uppercase tracking-widest text-muted-foreground">
+      {label}
+    </span>
+  );
+}
+
+export function DeferredWebGLPreview({
+  label,
+  children,
+}: {
+  label: string;
+  children: ReactNode;
+}) {
+  return (
+    <DeferredMount placeholder={<WebGLPlaceholder label={label} />}>
+      {children}
+    </DeferredMount>
+  );
+}

--- a/components/landing/previews/simple.tsx
+++ b/components/landing/previews/simple.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { useDialKit } from "dialkit";
+import { DemonicButton } from "@/components/evil-buttons/demonic-button";
+import ChromeButton from "@/components/evil-buttons/chrome-button";
+import GridButton from "@/components/evil-buttons/grid-button";
+import MinimalButton from "@/components/evil-buttons/minimal";
+import MoviePassButton from "@/components/evil-buttons/movie-pass";
+import ShinyButton from "@/components/evil-buttons/shiny-button";
+import StickyButton from "@/components/evil-buttons/sticky";
+import { ThreeDButton } from "@/components/evil-buttons/3d-button";
+import TrollButton from "@/components/evil-buttons/troll-button";
+import { DeferredWebGLPreview } from "./shared";
+
+export function DemonicButtonPreview() {
+  const p = useDialKit(
+    "DemonicButton",
+    { label: "Currupt the World" },
+    { id: "demonic-button" },
+  );
+
+  return <DemonicButton label={p.label} />;
+}
+
+export function ChromeButtonPreview() {
+  const p = useDialKit(
+    "ChromeButton",
+    { label: "Chromy" },
+    { id: "chrome-button" },
+  );
+
+  return (
+    <DeferredWebGLPreview label={p.label}>
+      <ChromeButton>{p.label}</ChromeButton>
+    </DeferredWebGLPreview>
+  );
+}
+
+export function GridButtonPreview() {
+  const p = useDialKit("GridButton", { label: "Click" }, { id: "grid-button" });
+
+  return <GridButton>{p.label}</GridButton>;
+}
+
+export function MinimalButtonPreview() {
+  const p = useDialKit("MinimalButton", { label: "Apply" }, { id: "minimal" });
+
+  return <MinimalButton>{p.label}</MinimalButton>;
+}
+
+export function MoviePassButtonPreview() {
+  const p = useDialKit(
+    "MoviePassButton",
+    { label: "Deploy Doom" },
+    { id: "movie-pass" },
+  );
+
+  return <MoviePassButton>{p.label}</MoviePassButton>;
+}
+
+export function ShinyButtonPreview() {
+  const p = useDialKit(
+    "ShinyButton",
+    { label: "Search" },
+    { id: "shiny-button" },
+  );
+
+  return <ShinyButton>{p.label}</ShinyButton>;
+}
+
+export function StickyButtonPreview() {
+  const p = useDialKit(
+    "StickyButton",
+    { label: "Try to Click" },
+    { id: "sticky" },
+  );
+
+  return <StickyButton>{p.label}</StickyButton>;
+}
+
+export function ThreeDButtonPreview() {
+  const p = useDialKit(
+    "ThreeDButton",
+    { label: "Continue" },
+    { id: "3d-button" },
+  );
+
+  return <ThreeDButton>{p.label}</ThreeDButton>;
+}
+
+export function TrollButtonPreview() {
+  const p = useDialKit(
+    "TrollButton",
+    { label: "Click Me" },
+    { id: "troll-button" },
+  );
+
+  return <TrollButton>{p.label}</TrollButton>;
+}

--- a/components/landing/previews/theme.ts
+++ b/components/landing/previews/theme.ts
@@ -1,0 +1,46 @@
+"use client";
+
+import { useDialKit, type DialConfig, type UseDialOptions } from "dialkit";
+import { useIsDarkMode } from "@/hooks/use-app-theme";
+
+export function useThemedDialKit<T extends DialConfig>(
+  name: string,
+  getConfig: (isDark: boolean) => T,
+  options?: UseDialOptions,
+) {
+  const isDark = useIsDarkMode();
+  return useDialKit(name, getConfig(isDark), options);
+}
+
+export const themeColors = {
+  light: {
+    background: "oklch(1 0 0)",
+    foreground: "oklch(0.145 0 0)",
+    muted: "oklch(0.97 0 0)",
+    primary: "oklch(0.205 0 0)",
+    primaryForeground: "oklch(0.985 0 0)",
+    border: "oklch(0.922 0 0)",
+    accent: "oklch(0.97 0 0)",
+  },
+  dark: {
+    background: "oklch(0.145 0 0)",
+    foreground: "oklch(0.985 0 0)",
+    muted: "oklch(0.269 0 0)",
+    primary: "oklch(0.922 0 0)",
+    primaryForeground: "oklch(0.205 0 0)",
+    border: "oklch(1 0 0 / 10%)",
+    accent: "oklch(0.269 0 0)",
+  },
+} as const;
+
+export function pillClassNames(isDark: boolean) {
+  return isDark
+    ? {
+        primaryClassName: "bg-neutral-950 text-neutral-200",
+        secondaryClassName: "bg-primary text-primary-foreground",
+      }
+    : {
+        primaryClassName: "bg-muted text-foreground",
+        secondaryClassName: "bg-primary text-primary-foreground",
+      };
+}

--- a/components/landing/previews/theme.ts
+++ b/components/landing/previews/theme.ts
@@ -12,24 +12,25 @@ export function useThemedDialKit<T extends DialConfig>(
   return useDialKit(name, getConfig(isDark), options);
 }
 
+// DialKit color controls require #RRGGBB hex — oklch() breaks the native picker.
 export const themeColors = {
   light: {
-    background: "oklch(1 0 0)",
-    foreground: "oklch(0.145 0 0)",
-    muted: "oklch(0.97 0 0)",
-    primary: "oklch(0.205 0 0)",
-    primaryForeground: "oklch(0.985 0 0)",
-    border: "oklch(0.922 0 0)",
-    accent: "oklch(0.97 0 0)",
+    background: "#ffffff",
+    foreground: "#1a1a1a",
+    muted: "#f5f5f5",
+    primary: "#1a1a1a",
+    primaryForeground: "#fafafa",
+    border: "#e5e5e5",
+    accent: "#f5f5f5",
   },
   dark: {
-    background: "oklch(0.145 0 0)",
-    foreground: "oklch(0.985 0 0)",
-    muted: "oklch(0.269 0 0)",
-    primary: "oklch(0.922 0 0)",
-    primaryForeground: "oklch(0.205 0 0)",
-    border: "oklch(1 0 0 / 10%)",
-    accent: "oklch(0.269 0 0)",
+    background: "#1a1a1a",
+    foreground: "#fafafa",
+    muted: "#404040",
+    primary: "#e5e5e5",
+    primaryForeground: "#1a1a1a",
+    border: "#333333",
+    accent: "#404040",
   },
 } as const;
 

--- a/components/landing/previews/utility.tsx
+++ b/components/landing/previews/utility.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { useDialKit } from "dialkit";
+import { useIsDarkMode } from "@/hooks/use-app-theme";
+import { pillClassNames, useThemedDialKit } from "./theme";
+import { CommandButton } from "@/components/evil-buttons/command-button";
+import { CopyButton } from "@/components/evil-buttons/copy-button";
+import { ClickPowerUp } from "@/components/evil-buttons/click-powerup";
+import { PillButton } from "@/components/evil-buttons/pill-button";
+
+export function CommandButtonPreview() {
+  const p = useDialKit(
+    "CommandButton",
+    {
+      label: "Save",
+      shortcut: "mod+s",
+      showShortcut: true,
+      preventDefault: true,
+    },
+    { id: "command-button" },
+  );
+
+  return (
+    <CommandButton
+      shortcut={p.shortcut}
+      showShortcut={p.showShortcut}
+      preventDefault={p.preventDefault}
+    >
+      {p.label}
+    </CommandButton>
+  );
+}
+
+export function CopyButtonPreview() {
+  const p = useDialKit(
+    "CopyButton",
+    {
+      value: "npx evil-buttons@latest init",
+      copyLabel: "Copy",
+      copiedLabel: "Copied",
+      timeout: [1500, 500, 5000],
+    },
+    { id: "copy-button" },
+  );
+
+  return (
+    <CopyButton
+      value={p.value}
+      copyLabel={p.copyLabel}
+      copiedLabel={p.copiedLabel}
+      timeout={p.timeout}
+    />
+  );
+}
+
+export function ClickPowerUpPreview() {
+  const p = useDialKit(
+    "ClickPowerUp",
+    {
+      label: "Doom",
+      tapDuration: [500, 200, 2000],
+    },
+    { id: "click-powerup" },
+  );
+
+  return <ClickPowerUp tapDuration={p.tapDuration}>{p.label}</ClickPowerUp>;
+}
+
+export function PillButtonPreview() {
+  const p = useThemedDialKit(
+    "PillButton",
+    () => ({
+      primaryLabel: "Off",
+      secondaryLabel: "On",
+      defaultOpen: false,
+    }),
+    { id: "pill-button" },
+  );
+  const isDark = useIsDarkMode();
+  const classes = pillClassNames(isDark);
+
+  return (
+    <PillButton
+      primaryLabel={p.primaryLabel}
+      secondaryLabel={p.secondaryLabel}
+      defaultOpen={p.defaultOpen}
+      primaryClassName={classes.primaryClassName}
+      secondaryClassName={classes.secondaryClassName}
+    />
+  );
+}

--- a/components/landing/previews/visual.tsx
+++ b/components/landing/previews/visual.tsx
@@ -27,7 +27,7 @@ export function BrutalButtonPreview() {
         radius: [0, 0, 24],
       };
     },
-    { id: "brutal-button" },
+    { id: "brutal-button-v2" },
   );
 
   return (
@@ -105,12 +105,12 @@ export function GlitchButtonPreview() {
 export function EvilEyeButtonPreview() {
   const p = useThemedDialKit(
     "EvilEyeButton",
-    (isDark) => ({
+    () => ({
       label: "Doom",
       effectOpacity: [0.95, 0, 1, 0.01],
       eye: {
         eyeColor: "#ff6f37",
-        backgroundColor: isDark ? "#050000" : "#f5f5f5",
+        backgroundColor: "#000000",
         intensity: [1.65, 0, 3, 0.01],
         pupilSize: [0.62, 0, 1, 0.01],
         irisWidth: [0.22, 0, 1, 0.01],
@@ -121,7 +121,7 @@ export function EvilEyeButtonPreview() {
         flameSpeed: [0.8, 0, 2, 0.01],
       },
     }),
-    { id: "evil-eye-button" },
+    { id: "evil-eye-button-v2" },
   );
 
   return (
@@ -209,7 +209,7 @@ export function HighlightButtonPreview() {
         borderColor: colors.foreground,
       };
     },
-    { id: "highlight-button" },
+    { id: "highlight-button-v2" },
   );
 
   return (

--- a/components/landing/previews/visual.tsx
+++ b/components/landing/previews/visual.tsx
@@ -1,0 +1,246 @@
+"use client";
+
+import { BrutalButton } from "@/components/evil-buttons/brutal-button";
+import DitherButton from "@/components/evil-buttons/dither-button";
+import { GlitchButton } from "@/components/evil-buttons/glitch-button";
+import EvilEyeButton from "@/components/evil-buttons/evil-eye-button";
+import { AquaButton } from "@/components/evil-buttons/aqua-button";
+import { FrameButton } from "@/components/evil-buttons/frame-button";
+import { HighlightButton } from "@/components/evil-buttons/highlight-button";
+import { ConfettiButton } from "@/components/evil-buttons/confetti-button";
+import { DeferredWebGLPreview } from "./shared";
+import { themeColors, useThemedDialKit } from "./theme";
+
+export function BrutalButtonPreview() {
+  const p = useThemedDialKit(
+    "BrutalButton",
+    (isDark) => {
+      const colors = isDark ? themeColors.dark : themeColors.light;
+      return {
+        label: "Click Me",
+        color: colors.background,
+        textColor: colors.foreground,
+        borderColor: colors.foreground,
+        shadowColor: colors.foreground,
+        hasBorder: true,
+        hasShadow: true,
+        radius: [0, 0, 24],
+      };
+    },
+    { id: "brutal-button" },
+  );
+
+  return (
+    <BrutalButton
+      color={p.color}
+      textColor={p.textColor}
+      borderColor={p.borderColor}
+      shadowColor={p.shadowColor}
+      hasBorder={p.hasBorder}
+      hasShadow={p.hasShadow}
+      radius={p.radius}
+    >
+      {p.label}
+    </BrutalButton>
+  );
+}
+
+export function DitherButtonPreview() {
+  const p = useThemedDialKit(
+    "DitherButton",
+    (isDark) => ({
+      label: "Run It",
+      ditherColor: isDark ? "#a3a3a3" : "#737373",
+      ditherOpacity: [1, 0, 1, 0.01],
+      ditherSize: [4, 1, 32],
+    }),
+    { id: "dither-button" },
+  );
+
+  return (
+    <DitherButton
+      ditherColor={p.ditherColor}
+      ditherOpacity={p.ditherOpacity}
+      ditherSize={p.ditherSize}
+    >
+      {p.label}
+    </DitherButton>
+  );
+}
+
+export function GlitchButtonPreview() {
+  const p = useThemedDialKit(
+    "GlitchButton",
+    (isDark) => ({
+      label: "Launch",
+      glitchInterval: [3500, 500, 8000],
+      glitchDuration: [450, 100, 1000],
+      channelA: isDark ? "#ef4444" : "#dc2626",
+      channelB: isDark ? "#22d3ee" : "#0891b2",
+      intensity: [1, 0, 3, 0.1],
+      trigger: {
+        type: "select",
+        options: ["auto", "hover", "always"],
+        default: "hover",
+      },
+      scanlines: true,
+    }),
+    { id: "glitch-button" },
+  );
+
+  return (
+    <GlitchButton
+      glitchInterval={p.glitchInterval}
+      glitchDuration={p.glitchDuration}
+      colors={[p.channelA, p.channelB]}
+      intensity={p.intensity}
+      trigger={p.trigger as "auto" | "hover" | "always"}
+      scanlines={p.scanlines}
+    >
+      {p.label}
+    </GlitchButton>
+  );
+}
+
+export function EvilEyeButtonPreview() {
+  const p = useThemedDialKit(
+    "EvilEyeButton",
+    (isDark) => ({
+      label: "Doom",
+      effectOpacity: [0.95, 0, 1, 0.01],
+      eye: {
+        eyeColor: "#ff6f37",
+        backgroundColor: isDark ? "#050000" : "#f5f5f5",
+        intensity: [1.65, 0, 3, 0.01],
+        pupilSize: [0.62, 0, 1, 0.01],
+        irisWidth: [0.22, 0, 1, 0.01],
+        glowIntensity: [0.56, 0, 1, 0.01],
+        scale: [1.15, 0.5, 2, 0.01],
+        noiseScale: [1, 0, 2, 0.01],
+        pupilFollow: [0.55, 0, 1, 0.01],
+        flameSpeed: [0.8, 0, 2, 0.01],
+      },
+    }),
+    { id: "evil-eye-button" },
+  );
+
+  return (
+    <DeferredWebGLPreview label={p.label}>
+      <EvilEyeButton
+        effectOpacity={p.effectOpacity}
+        eyeColor={p.eye.eyeColor}
+        backgroundColor={p.eye.backgroundColor}
+        intensity={p.eye.intensity}
+        pupilSize={p.eye.pupilSize}
+        irisWidth={p.eye.irisWidth}
+        glowIntensity={p.eye.glowIntensity}
+        scale={p.eye.scale}
+        noiseScale={p.eye.noiseScale}
+        pupilFollow={p.eye.pupilFollow}
+        flameSpeed={p.eye.flameSpeed}
+      >
+        {p.label}
+      </EvilEyeButton>
+    </DeferredWebGLPreview>
+  );
+}
+
+export function AquaButtonPreview() {
+  const p = useThemedDialKit(
+    "AquaButton",
+    () => ({
+      label: "Deploy Doom",
+      variant: {
+        type: "select",
+        options: ["primary", "secondary"],
+        default: "primary",
+      },
+    }),
+    { id: "aqua-button" },
+  );
+
+  return (
+    <AquaButton variant={p.variant as "primary" | "secondary"}>
+      {p.label}
+    </AquaButton>
+  );
+}
+
+export function FrameButtonPreview() {
+  const p = useThemedDialKit(
+    "FrameButton",
+    () => ({
+      label: "Deploy",
+      variant: {
+        type: "select",
+        options: ["default", "secondary", "outline"],
+        default: "default",
+      },
+      glow: false,
+      size: [20, 8, 40],
+      offset: [7.5, 0, 20, 0.5],
+      hoverOffset: [7, 0, 20, 0.5],
+    }),
+    { id: "frame-button" },
+  );
+
+  return (
+    <FrameButton
+      variant={p.variant as "default" | "secondary" | "outline"}
+      glow={p.glow}
+      size={p.size}
+      offset={p.offset}
+      hoverOffset={p.hoverOffset}
+    >
+      {p.label}
+    </FrameButton>
+  );
+}
+
+export function HighlightButtonPreview() {
+  const p = useThemedDialKit(
+    "HighlightButton",
+    (isDark) => {
+      const colors = isDark ? themeColors.dark : themeColors.light;
+      return {
+        label: "Send",
+        highlightColor: colors.foreground,
+        highlightSize: [56, 20, 120],
+        borderColor: colors.foreground,
+      };
+    },
+    { id: "highlight-button" },
+  );
+
+  return (
+    <HighlightButton
+      highlightColor={p.highlightColor}
+      highlightSize={p.highlightSize}
+      borderColor={p.borderColor}
+    >
+      {p.label}
+    </HighlightButton>
+  );
+}
+
+export function ConfettiButtonPreview() {
+  const p = useThemedDialKit(
+    "ConfettiButton",
+    () => ({
+      label: "Celebrate",
+      particleCount: [120, 20, 300],
+      spread: [72, 20, 180],
+      startVelocity: [38, 10, 80],
+    }),
+    { id: "confetti-button" },
+  );
+
+  return (
+    <ConfettiButton
+      label={p.label}
+      particleCount={p.particleCount}
+      spread={p.spread}
+      startVelocity={p.startVelocity}
+    />
+  );
+}

--- a/components/landing/showcase.ts
+++ b/components/landing/showcase.ts
@@ -1,0 +1,37 @@
+export type ShowcaseEntry = {
+  name: string;
+  href: string;
+  registryName: string;
+};
+
+export const showcase: ShowcaseEntry[] = [
+  { name: "RevealButton", href: "/docs/reveal-button", registryName: "reveal-button" },
+  { name: "CommandButton", href: "/docs/command-button", registryName: "command-button" },
+  { name: "CopyButton", href: "/docs/copy-button", registryName: "copy-button" },
+  { name: "ClickPowerUp", href: "/docs/click-power-up", registryName: "click-powerup" },
+  { name: "DitherButton", href: "/docs/dither-button", registryName: "dither-button" },
+  { name: "HoldButton", href: "/docs/hold-button", registryName: "hold-button" },
+  { name: "DemonicButton", href: "/docs/demonic-button", registryName: "demonic-button" },
+  { name: "EvilEyeButton", href: "/docs/evil-eye-button", registryName: "evil-eye-button" },
+  { name: "AquaButton", href: "/docs/aqua-button", registryName: "aqua-button" },
+  { name: "BrutalButton", href: "/docs/brutal-button", registryName: "brutal-button" },
+  { name: "ChromeButton", href: "/docs/chrome-button", registryName: "chrome-button" },
+  { name: "FrameButton", href: "/docs/frame-button", registryName: "frame-button" },
+  { name: "GlitchButton", href: "/docs/glitch-button", registryName: "glitch-button" },
+  { name: "GridButton", href: "/docs/grid-button", registryName: "grid-button" },
+  { name: "HighlightButton", href: "/docs/highlight-button", registryName: "highlight-button" },
+  { name: "MinimalButton", href: "/docs/minimal-button", registryName: "minimal" },
+  { name: "MoviePassButton", href: "/docs/movie-pass", registryName: "movie-pass" },
+  { name: "ShinyButton", href: "/docs/shiny-button", registryName: "shiny-button" },
+  { name: "StickyButton", href: "/docs/sticky-button", registryName: "sticky" },
+  { name: "ThreeDButton", href: "/docs/3d-button", registryName: "3d-button" },
+  { name: "TrollButton", href: "/docs/troll-button", registryName: "troll-button" },
+  { name: "CaptchaButton", href: "/docs/captcha-button", registryName: "captcha-button" },
+  { name: "DoubtButton", href: "/docs/doubt-button", registryName: "doubt-button" },
+  { name: "SlideToDetonate", href: "/docs/slide-to-detonate", registryName: "slide-to-detonate" },
+  { name: "MorphStatusButton", href: "/docs/morph-status-button", registryName: "morph-status-button" },
+  { name: "CooldownButton", href: "/docs/cooldown-button", registryName: "cooldown-button" },
+  { name: "PillButton", href: "/docs/pill-button", registryName: "pill-button" },
+  { name: "ConfettiButton", href: "/docs/confetti-button", registryName: "confetti-button" },
+  { name: "HoldConfirmButton", href: "/docs/hold-confirm-button", registryName: "hold-confirm-button" },
+];

--- a/components/theme-sync.tsx
+++ b/components/theme-sync.tsx
@@ -1,49 +1,28 @@
 "use client";
 
 import { useEffect } from "react";
+import {
+  applyTheme,
+  readPreferredTheme,
+  THEME_STORAGE_KEY,
+  toggleTheme,
+  type ThemePreference,
+} from "@/lib/theme-preference";
 
-const THEME_STORAGE_KEY = "theme";
-const DARK_THEME = "dark";
-const LIGHT_THEME = "light";
 const EDITABLE_SELECTOR = "input, textarea, select, [contenteditable='true']";
-
-function readPreferredTheme() {
-  const stored = localStorage.getItem(THEME_STORAGE_KEY);
-
-  if (stored === DARK_THEME || stored === LIGHT_THEME) {
-    return stored;
-  }
-
-  return window.matchMedia("(prefers-color-scheme: dark)").matches
-    ? DARK_THEME
-    : LIGHT_THEME;
-}
-
-function applyTheme(theme: typeof DARK_THEME | typeof LIGHT_THEME) {
-  document.documentElement.classList.toggle("dark", theme === DARK_THEME);
-}
 
 export function ThemeSync() {
   useEffect(() => {
     applyTheme(readPreferredTheme());
 
     const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key.toLowerCase() !== "d") {
-        return;
-      }
-
+      if (event.key.toLowerCase() !== "d") return;
       if ((event.target as HTMLElement | null)?.closest(EDITABLE_SELECTOR)) {
         return;
       }
 
       event.preventDefault();
-
-      const nextTheme = document.documentElement.classList.contains("dark")
-        ? LIGHT_THEME
-        : DARK_THEME;
-
-      applyTheme(nextTheme);
-      localStorage.setItem(THEME_STORAGE_KEY, nextTheme);
+      toggleTheme();
     };
 
     window.addEventListener("keydown", onKeyDown);
@@ -52,3 +31,5 @@ export function ThemeSync() {
 
   return null;
 }
+
+export { THEME_STORAGE_KEY, type ThemePreference };

--- a/components/theme-toggle.tsx
+++ b/components/theme-toggle.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { Moon, Sun } from "@phosphor-icons/react";
+import { Button } from "@/components/ui/button";
+import { useAppTheme } from "@/hooks/use-app-theme";
+import { toggleTheme } from "@/lib/theme-preference";
+
+export function ThemeToggle() {
+  const theme = useAppTheme();
+  const isDark = theme === "dark";
+
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      size="icon-sm"
+      className="shrink-0 rounded-none"
+      onClick={toggleTheme}
+      aria-label={isDark ? "Switch to light mode" : "Switch to dark mode"}
+    >
+      {isDark ? <Sun weight="bold" /> : <Moon weight="bold" />}
+    </Button>
+  );
+}

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -1,0 +1,192 @@
+"use client"
+
+import * as React from "react"
+import { Select as SelectPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+import { CaretDownIcon, CheckIcon, CaretUpIcon } from "@phosphor-icons/react"
+
+function Select({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Root>) {
+  return <SelectPrimitive.Root data-slot="select" {...props} />
+}
+
+function SelectGroup({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Group>) {
+  return (
+    <SelectPrimitive.Group
+      data-slot="select-group"
+      className={cn("scroll-my-1 p-1", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectValue({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Value>) {
+  return <SelectPrimitive.Value data-slot="select-value" {...props} />
+}
+
+function SelectTrigger({
+  className,
+  size = "default",
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
+  size?: "sm" | "default"
+}) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
+      data-size={size}
+      className={cn(
+        "flex w-fit items-center justify-between gap-1.5 rounded-lg border border-input bg-transparent py-2 pr-2 pl-2.5 text-sm whitespace-nowrap transition-colors outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-placeholder:text-muted-foreground data-[size=default]:h-8 data-[size=sm]:h-7 data-[size=sm]:rounded-[min(var(--radius-md),10px)] *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon asChild>
+        <CaretDownIcon className="pointer-events-none size-4 text-muted-foreground" />
+      </SelectPrimitive.Icon>
+    </SelectPrimitive.Trigger>
+  )
+}
+
+function SelectContent({
+  className,
+  children,
+  position = "item-aligned",
+  align = "center",
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Content>) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Content
+        data-slot="select-content"
+        data-align-trigger={position === "item-aligned"}
+        className={cn("relative z-50 max-h-(--radix-select-content-available-height) min-w-36 origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[align-trigger=true]:animate-none data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95", position ==="popper"&&"data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1", className )}
+        position={position}
+        align={align}
+        {...props}
+      >
+        <SelectScrollUpButton />
+        <SelectPrimitive.Viewport
+          data-position={position}
+          className={cn(
+            "data-[position=popper]:h-(--radix-select-trigger-height) data-[position=popper]:w-full data-[position=popper]:min-w-(--radix-select-trigger-width)",
+            position === "popper" && ""
+          )}
+        >
+          {children}
+        </SelectPrimitive.Viewport>
+        <SelectScrollDownButton />
+      </SelectPrimitive.Content>
+    </SelectPrimitive.Portal>
+  )
+}
+
+function SelectLabel({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Label>) {
+  return (
+    <SelectPrimitive.Label
+      data-slot="select-label"
+      className={cn("px-1.5 py-1 text-xs text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Item>) {
+  return (
+    <SelectPrimitive.Item
+      data-slot="select-item"
+      className={cn(
+        "relative flex w-full cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        className
+      )}
+      {...props}
+    >
+      <span className="pointer-events-none absolute right-2 flex size-4 items-center justify-center">
+        <SelectPrimitive.ItemIndicator>
+          <CheckIcon className="pointer-events-none" />
+        </SelectPrimitive.ItemIndicator>
+      </span>
+      <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    </SelectPrimitive.Item>
+  )
+}
+
+function SelectSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Separator>) {
+  return (
+    <SelectPrimitive.Separator
+      data-slot="select-separator"
+      className={cn("pointer-events-none -mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectScrollUpButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpButton>) {
+  return (
+    <SelectPrimitive.ScrollUpButton
+      data-slot="select-scroll-up-button"
+      className={cn(
+        "z-10 flex cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <CaretUpIcon
+      />
+    </SelectPrimitive.ScrollUpButton>
+  )
+}
+
+function SelectScrollDownButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownButton>) {
+  return (
+    <SelectPrimitive.ScrollDownButton
+      data-slot="select-scroll-down-button"
+      className={cn(
+        "z-10 flex cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <CaretDownIcon
+      />
+    </SelectPrimitive.ScrollDownButton>
+  )
+}
+
+export {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+}

--- a/hooks/use-app-theme.ts
+++ b/hooks/use-app-theme.ts
@@ -1,0 +1,30 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+
+export type AppTheme = "light" | "dark";
+
+function getThemeSnapshot(): AppTheme {
+  if (typeof document === "undefined") return "light";
+  return document.documentElement.classList.contains("dark") ? "dark" : "light";
+}
+
+function subscribeToTheme(onStoreChange: () => void) {
+  if (typeof document === "undefined") return () => undefined;
+
+  const observer = new MutationObserver(onStoreChange);
+  observer.observe(document.documentElement, {
+    attributes: true,
+    attributeFilter: ["class"],
+  });
+
+  return () => observer.disconnect();
+}
+
+export function useAppTheme(): AppTheme {
+  return useSyncExternalStore(subscribeToTheme, getThemeSnapshot, () => "light");
+}
+
+export function useIsDarkMode() {
+  return useAppTheme() === "dark";
+}

--- a/hooks/use-is-mobile.ts
+++ b/hooks/use-is-mobile.ts
@@ -1,0 +1,25 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+
+const MOBILE_QUERY = "(max-width: 639px)";
+
+function subscribe(onStoreChange: () => void) {
+  if (typeof window === "undefined") return () => undefined;
+
+  const media = window.matchMedia(MOBILE_QUERY);
+  media.addEventListener("change", onStoreChange);
+  return () => media.removeEventListener("change", onStoreChange);
+}
+
+function getSnapshot() {
+  return window.matchMedia(MOBILE_QUERY).matches;
+}
+
+function getServerSnapshot() {
+  return false;
+}
+
+export function useIsMobile() {
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}

--- a/lib/theme-preference.ts
+++ b/lib/theme-preference.ts
@@ -1,0 +1,26 @@
+export const THEME_STORAGE_KEY = "theme";
+
+export type ThemePreference = "light" | "dark";
+
+export function readPreferredTheme(): ThemePreference {
+  if (typeof window === "undefined") return "light";
+
+  const stored = localStorage.getItem(THEME_STORAGE_KEY);
+  if (stored === "dark" || stored === "light") return stored;
+
+  return window.matchMedia("(prefers-color-scheme: dark)").matches
+    ? "dark"
+    : "light";
+}
+
+export function applyTheme(theme: ThemePreference) {
+  document.documentElement.classList.toggle("dark", theme === "dark");
+}
+
+export function toggleTheme() {
+  const nextTheme: ThemePreference =
+    document.documentElement.classList.contains("dark") ? "light" : "dark";
+
+  applyTheme(nextTheme);
+  localStorage.setItem(THEME_STORAGE_KEY, nextTheme);
+}

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "canvas-confetti": "^1.9.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "dialkit": "^1.3.0",
     "fumadocs-core": "^16.8.5",
     "fumadocs-mdx": "^14.3.2",
     "motion": "^12.38.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      dialkit:
+        specifier: ^1.3.0
+        version: 1.3.0(motion@12.38.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       fumadocs-core:
         specifier: ^16.8.5
         version: 16.8.5(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(next@16.2.6(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6)
@@ -2332,6 +2335,30 @@ packages:
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
+
+  dialkit@1.3.0:
+    resolution: {integrity: sha512-//tnKhG+6gWhH3h9L7RpRPQZJkRBj0qQyUu1Og1l0VI6Nn/7iKaZZDFs/hG+Jsrtvwp4hlLrrmzj8M6hkXR3EA==}
+    peerDependencies:
+      motion: '>=11.0.0'
+      motion-v: '>=2.0.0'
+      react: '>=18.0.0'
+      react-dom: '>=18.0.0'
+      solid-js: '>=1.6.0'
+      svelte: '>=5.8.0'
+      vue: '>=3.3.0'
+    peerDependenciesMeta:
+      motion-v:
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+      solid-js:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
 
   diff@8.0.4:
     resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
@@ -6759,6 +6786,13 @@ snapshots:
   devlop@1.1.0:
     dependencies:
       dequal: 2.0.3
+
+  dialkit@1.3.0(motion@12.38.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      motion: 12.38.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+    optionalDependencies:
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
 
   diff@8.0.4: {}
 


### PR DESCRIPTION
## Summary

Replaces the grid-based landing page with a focused preview experience: users pick a button from a shadcn Select dropdown and see it centered on the page with live DialKit controls.

## Changes

- Install DialKit and wire DialRoot in the root layout
- Add shadcn Select for button picker (sharp corners)
- Per-button DialKit preview components with tailored controls for all 29 buttons
- Theme-aware dial defaults and DialKit panel styling synced with light/dark mode (toggle with D)
- DialKit panel positioned top-left below the header
- Remove navbar and footer borders for a cleaner layout

## Test plan

- [ ] Open landing page, switch buttons via dropdown
- [ ] Tweak controls in DialKit panel and confirm live updates
- [ ] Toggle light/dark with D — page, panel, and button previews update
- [ ] Confirm DialKit panel does not overlap header